### PR TITLE
Update CSC121 W3 LAB Problem 6

### DIFF
--- a/CSC121 W3 LAB Problem 6
+++ b/CSC121 W3 LAB Problem 6
@@ -12,20 +12,21 @@ int main() {
     double payment = 0.0;
 
     // Input
+    while (true) {
     cout << "Enter destination code (KL or KB): ";
     cin >> destinationCode;
 
     // Convert to uppercase immediately
-    for (char &c : destinationCode) {
-        c = toupper(c);
+        for (std::string::size_type i = 0; i < destinationCode.size(); ++i) {
+            destinationCode[i] = toupper(destinationCode[i]);
     }
 
-    // Validate destination code early
-    if (destinationCode != "KL" && destinationCode != "KB") {
+    if (destinationCode == "KL" || destinationCode == "KB") {
+        break; // valid input, break the loop
+    } else {
         cout << "Invalid destination code. Must be KL or KB." << endl;
-        return 1;
     }
-
+}
     cout << "Enter quantity: ";
     cin >> quantity;
 


### PR DESCRIPTION
Previously, entering an invalid destination code (other than "KL" or "KB") would cause the program to exit immediately. This change introduces a while loop that continuously prompts the user until a valid destination code is entered.

Also changed a block of code that wasn't C++98-compatible